### PR TITLE
Sort all imports across .py files

### DIFF
--- a/bot/exts/fun/catify.py
+++ b/bot/exts/fun/catify.py
@@ -1,5 +1,5 @@
-import random
 from contextlib import suppress
+import random
 from typing import Optional
 
 from discord import AllowedMentions, Embed, Forbidden

--- a/bot/exts/fun/fun.py
+++ b/bot/exts/fun/fun.py
@@ -4,8 +4,8 @@ import discord
 from discord.ext import commands
 import pytz
 
-from bot.utilities.tio import Tio
 from bot.utilities import get_yaml_val
+from bot.utilities.tio import Tio
 
 cst = pytz.timezone("US/Central")
 

--- a/bot/exts/fun/makeembed.py
+++ b/bot/exts/fun/makeembed.py
@@ -1,7 +1,9 @@
-import discord
-from discord.ext import commands
 import asyncio
 import datetime
+
+import discord
+from discord.ext import commands
+
 from bot.utilities import get_yaml_val
 
 

--- a/bot/exts/fun/zencat.py
+++ b/bot/exts/fun/zencat.py
@@ -1,13 +1,11 @@
+from collections import OrderedDict
 import random
+from typing import Optional
 
 import discord
 from discord.ext import commands
 
-from typing import Optional
-
 from bot.utilities import get_yaml_val
-
-from collections import OrderedDict
 
 COLORS = get_yaml_val("bot/config.yml", "colors")["colors"]
 

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -5,7 +5,6 @@ import os
 import discord
 from discord.ext import commands, tasks
 
-
 from bot.utilities import get_yaml_val
 
 GUILD_ID = get_yaml_val("bot/config.yml", "guild.id")

--- a/bot/exts/utilities/help.py
+++ b/bot/exts/utilities/help.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from discord.ext import commands
 import discord
+from discord.ext import commands
 
 from bot.utilities import get_yaml_val
 

--- a/bot/exts/utilities/quote.py
+++ b/bot/exts/utilities/quote.py
@@ -1,10 +1,13 @@
-from discord.ext import commands
-import discord
+import asyncio
 import json
 import random
-import asyncio
-from bot.utilities import get_yaml_val
 import re
+
+import discord
+from discord.ext import commands
+
+from bot.utilities import get_yaml_val
+
 quotechannel = get_yaml_val("bot/config.yml", 'guild')['guild']["channels"]["quotes"]
 
 

--- a/bot/exts/utilities/timeconvert.py
+++ b/bot/exts/utilities/timeconvert.py
@@ -1,9 +1,9 @@
-import pytz
 import datetime
 from typing import Optional
 
-from discord.ext import commands
 import discord
+from discord.ext import commands
+import pytz
 
 from bot.utilities import get_yaml_val
 

--- a/bot/utilities/__init__.py
+++ b/bot/utilities/__init__.py
@@ -1,7 +1,7 @@
 def get_yaml_val(yaml_file: str, *strings: str) -> dict:
+    from string import punctuation
 
     import yaml
-    from string import punctuation
 
     return_dict = {}
 

--- a/bot/utilities/tio.py
+++ b/bot/utilities/tio.py
@@ -1,8 +1,8 @@
-"Library to interact asynchronously with tio.run"
+"""Library to interact asynchronously with tio.run"""
 
 from functools import partial
-from urllib.request import Request, urlopen
 from gzip import decompress
+from urllib.request import Request, urlopen
 from zlib import compress
 
 import aiohttp


### PR DESCRIPTION
In alphabetical order, imports should be separated into three groups:

1. stdlibs
2. third-party
3. local applications 

However, our current code has lots of inconsistencies with this order. This PR fixes them all.